### PR TITLE
Fix typo error in entity_properties.mdx

### DIFF
--- a/src/content/docs/current/Reference/Miscellaneous/entity_properties.mdx
+++ b/src/content/docs/current/Reference/Miscellaneous/entity_properties.mdx
@@ -16,7 +16,7 @@ entity.<ID> = [<namespace>:]<entity_id>
 entity.1 = minecraft:skeleton minecraft:sheep
 ```
 
-The optional namespace allows support for modded entities. Multiple entities can be assigned to a single ID, however a single entity can only be assigned to a single ID. IDs are stored internally as 16-bit unsigned integers, and can store values between `0` and `65535`.
+The optional namespace allows support for modded entities. Multiple entities can be assigned to a single ID, however a single ID can only be assigned to a single entity. IDs are stored internally as 16-bit unsigned integers, and can store values between `0` and `65535`.
 
 ### Hardcoded IDs
 The following IDs do not exist in Minecraft but are hardcoded by Iris:


### PR DESCRIPTION
Small correction. The sentence doesn't make sense otherwise.