### PR TITLE
Small typo fix in rendertargets.mdx

### DIFF
--- a/src/content/docs/current/Reference/Constants/rendertargets.mdx
+++ b/src/content/docs/current/Reference/Constants/rendertargets.mdx
@@ -18,7 +18,7 @@ This directive is used to configure which color attachments a fragment program o
 This directive *must* include be a multi-line comment (as opposed to a single-line comment, `//`) and should be on its own line.
 :::
 
-The directive creates a map between the color attachment index used in the GLSL code and the [colortex](/current/reference/buffers/colortex) or [shadowcolor](/current/reference/buffers/shadowcolor) buffer. For example, if the line `/* RENDERTARGETS: 0,3,7,13 */` is used, `colortex0` would be at index 0 and `colortex13` at index 3. There are three methods to access this output depending on the GLSL version in use:
+The directive creates a map between the color attachment index used in the GLSL code and the [colortex](/current/reference/buffers/colortex) or [shadowcolor](/current/reference/buffers/shadowcolor) buffer. For example, if the line `/* RENDERTARGETS: 0,3,7,13 */` is used, `colortex0` would be at index 0 and `colortex1` at index 3. There are three methods to access this output depending on the GLSL version in use:
 
 1. Legacy versions and compatibility profiles have access to `gl_FragData[<index>]`, an array that can be written to with the attachment index like a standard `vec4` array. In the above example writing to `gl_FragData[2]` would write to `colortex7`.
 2. Modern versions (130+) can use the `out vec4 outColorN;` variable, where `N` is replaced with the array index. In the above example writing to `outColor2` would write to `colortex7`.


### PR DESCRIPTION
changed colortex13 to colortex1, since I believe this was a typo